### PR TITLE
feat: add product_exists property to the line item fields

### DIFF
--- a/src/Enum/Fields/LineItemFields.php
+++ b/src/Enum/Fields/LineItemFields.php
@@ -11,6 +11,7 @@ class LineItemFields extends AbstractObjectEnum
     const ID = 'id';
     const PRICE = 'price';
     const PRODUCT_ID = 'product_id';
+    const PRODUCT_EXISTS = 'product_exists';
     const QUANTITY = 'quantity';
     const REQUIRES_SHIPPING = 'requires_shipping';
     const SKU = 'sku';
@@ -41,6 +42,7 @@ class LineItemFields extends AbstractObjectEnum
             'id' => 'integer',
             'price' => 'string',
             'product_id' => 'integer',
+            'product_exists' => 'boolean',
             'quantity' => 'integer',
             'requires_shipping' => 'boolean',
             'sku' => 'string',


### PR DESCRIPTION
### Additions

-   Add the 'product_exists' property to the line item fields. This is a field that exists only on the response object of order and defines if a product is a temp product/item or not

### Documentation

[Response payload](https://shopify.dev/api/admin-rest/2022-10/resources/order#get-orders-order-id)
[more on product_exists](https://community.shopify.com/c/shopify-apis-and-sdks/order-webhook-with-null-product-id/m-p/1683721/highlight/true#M82077)