### PR TITLE
bug: fix wrong constructed url for cancel order endpoint

### DIFF
--- a/src/Service/OrderService.php
+++ b/src/Service/OrderService.php
@@ -107,7 +107,7 @@ class OrderService extends AbstractService
      */
     public function cancel(Order &$order)
     {
-        $endpoint = '/orders/' . $order->id . '/cancel.json';
+        $endpoint = 'orders/' . $order->id . '/cancel.json';
         $response = $this->request($endpoint, 'POST');
         $order->setData($response['order']);
     }


### PR DESCRIPTION
the `/` prevents the order from being cancel with a response error 

```
Client error: `POST [https://chicco-kids.myshopify.com/orders/4936556839146/cancel.json`](https://test.myshopify.com/orders/xxxxxxxxxxxxxxx/cancel.json) resulted in a 404 Not Found response
```