### PR TITLE
Fix fulfilment service endpoints

### DIFF
--- a/src/Enum/Fields/FulfillmentFields.php
+++ b/src/Enum/Fields/FulfillmentFields.php
@@ -9,7 +9,7 @@ class FulfillmentFields extends AbstractObjectEnum
     const LINE_ITEMS = 'line_items';
     const NOTIFY_CUSTOMER = 'notify_customer';
     const TRACKING_INFO = 'tracking_info';
-    const LINE_ITEMS_BY_FULFILMENT_ORDER = 'line_items_by_fulfillment_order';
+    const LINE_ITEMS_BY_FULFILLMENT_ORDER = 'line_items_by_fulfillment_order';
     const ORDER_ID = 'order_id';
     const RECEIPT = 'receipt';
     const STATUS = 'status';

--- a/src/Enum/Fields/FulfillmentFields.php
+++ b/src/Enum/Fields/FulfillmentFields.php
@@ -8,6 +8,8 @@ class FulfillmentFields extends AbstractObjectEnum
     const ID = 'id';
     const LINE_ITEMS = 'line_items';
     const NOTIFY_CUSTOMER = 'notify_customer';
+    const TRACKING_INFO = 'tracking_info';
+    const LINE_ITEMS_BY_FULFILMENT_ORDER = 'line_items_by_fulfillment_order';
     const ORDER_ID = 'order_id';
     const RECEIPT = 'receipt';
     const STATUS = 'status';
@@ -25,6 +27,8 @@ class FulfillmentFields extends AbstractObjectEnum
             'id' => 'integer',
             'line_items' => 'LineItem[]',
             'notify_customer' => 'boolean',
+            'tracking_info' => 'TrackingInfo[]',
+            'line_items_by_fulfillment_order' => 'LineItemByFulfillmentOrder[]',
             'order_id' => 'integer',
             'receipt' => "object",
             'status' => 'string',

--- a/src/Enum/Fields/FulfillmentFields.php
+++ b/src/Enum/Fields/FulfillmentFields.php
@@ -27,7 +27,7 @@ class FulfillmentFields extends AbstractObjectEnum
             'id' => 'integer',
             'line_items' => 'LineItem[]',
             'notify_customer' => 'boolean',
-            'tracking_info' => 'TrackingInfo[]',
+            'tracking_info' => 'TrackingInfo',
             'line_items_by_fulfillment_order' => 'LineItemByFulfillmentOrder[]',
             'order_id' => 'integer',
             'receipt' => "object",

--- a/src/Enum/Fields/LineItemByFulfillmentOrderFields.php
+++ b/src/Enum/Fields/LineItemByFulfillmentOrderFields.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Shopify\Enum\Fields;
+
+class LineItemByFulfillmentOrderFields extends AbstractObjectEnum
+{
+    const FULFILLMENT_ORDER_ID = 'fulfillment_order_id';
+
+    public function getFieldTypes()
+    {
+        return array(
+            'fulfillment_order_id' => 'integer',
+        );
+    }
+}

--- a/src/Enum/Fields/TrackingInfoFields.php
+++ b/src/Enum/Fields/TrackingInfoFields.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Shopify\Enum\Fields;
+
+class TrackingInfoFields extends AbstractObjectEnum
+{
+    const COMPANY = 'company';
+    const NUMBER = 'number';
+    const URL = 'url';
+
+    public function getFieldTypes()
+    {
+        return [
+            'company' => 'string',
+            'number' => 'string',
+            'url' => 'string',
+        ];
+    }
+}

--- a/src/Object/LineItemByFulfillmentOrder.php
+++ b/src/Object/LineItemByFulfillmentOrder.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Shopify\Object;
+
+
+use Shopify\Enum\Fields\LineItemByFulfillmentOrderFields;
+
+class LineItemByFulfillmentOrder extends AbstractObject
+{
+    public static function getFieldsEnum()
+    {
+        return LineItemByFulfillmentOrderFields::getInstance();
+    }
+}

--- a/src/Object/TrackingInfo.php
+++ b/src/Object/TrackingInfo.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Shopify\Object;
+
+
+use Shopify\Enum\Fields\TrackingInfoFields;
+
+class TrackingInfo extends AbstractObject
+{
+    public static function getFieldsEnum()
+    {
+        return TrackingInfoFields::getInstance();
+    }
+}

--- a/src/Service/FulfillmentService.php
+++ b/src/Service/FulfillmentService.php
@@ -27,6 +27,14 @@ class FulfillmentService extends AbstractService
         return $this->createObject(Fulfillment::class, $response['fulfillments']);
     }
 
+    public function getFulfilledOrder(Fulfillment &$fulfillment)
+    {
+        $endpoint = 'fulfillment_orders/' . $fulfillment->id . '/fulfillments.json';
+        $response = $this->request($endpoint, 'GET');
+
+        return $this->createObject(Fulfillment::class, $response['fulfillments']);
+    }
+
     public function create(Fulfillment &$fulfillment)
     {
         $data = $fulfillment->exportData();

--- a/src/Service/FulfillmentService.php
+++ b/src/Service/FulfillmentService.php
@@ -27,10 +27,10 @@ class FulfillmentService extends AbstractService
         return $this->createObject(Fulfillment::class, $response['fulfillments']);
     }
 
-    public function create($orderId, Fulfillment &$fulfillment)
+    public function create(Fulfillment &$fulfillment)
     {
         $data = $fulfillment->exportData();
-        $endpoint = 'orders/' . $orderId . '/fulfillments.json';
+        $endpoint = 'fulfillments.json';
         $response = $this->request(
             $endpoint,
             'POST',
@@ -41,10 +41,10 @@ class FulfillmentService extends AbstractService
         $fulfillment->setData($response['fulfillment']);
     }
 
-    public function update($orderId, Fulfillment &$fulfillment)
+    public function updateTracking(Fulfillment &$fulfillment)
     {
         $data = $fulfillment->exportData();
-        $endpoint = 'orders/' . $orderId . '/fulfillments/' . $fulfillment->id . '.json';
+        $endpoint = 'fulfillments/' . $fulfillment->id . '/update_tracking.json';
         $response = $this->request(
             $endpoint,
             'PUT',
@@ -55,24 +55,10 @@ class FulfillmentService extends AbstractService
         $fulfillment->setData($response['fulfillment']);
     }
 
-    public function complete($orderId, Fulfillment &$fulfillment)
+    public function cancel(Fulfillment &$fulfillment)
     {
-        $endpoint = 'orders/' . $orderId . '/fulfillments/' . $fulfillment->id . '/complete.json';
+        $endpoint = 'fulfillments/' . $fulfillment->id . '/cancel.json';
         $response = $this->request($endpoint, 'POST');
         $fulfillment->setData($response['fulfillment']);
-    }
-
-    public function cancel($orderId, Fulfillment &$fulfillment)
-    {
-        $endpoint = 'orders/' . $orderId . '/fulfillments/' . $fulfillment->id . '/cancel.json';
-        $response = $this->request($endpoint, 'POST');
-        $fulfillment->setData($response['fulfillment']);
-    }
-
-    public function open($orderId, Fulfillment &$fulfillment)
-    {
-        $endpoint = 'orders/' . $orderId . '/fulfillments/' . $fulfillment->id . '/open.json';
-        $response = $this->request($endpoint, 'POST');
-        $fulfillment->setData($response->fulfillment);
     }
 }

--- a/src/Service/FulfillmentService.php
+++ b/src/Service/FulfillmentService.php
@@ -47,7 +47,7 @@ class FulfillmentService extends AbstractService
         $endpoint = 'fulfillments/' . $fulfillment->id . '/update_tracking.json';
         $response = $this->request(
             $endpoint,
-            'PUT',
+            'POST',
             [
                 'fulfillment' => $data
             ]


### PR DESCRIPTION
[Fulfillment endpoints removed from the REST Admin API](https://shopify.dev/api/release-notes/2022-07#fulfillment-endpoints-removed-from-the-rest-admin-api)

As of API version 2022-07, the following endpoints have been removed from the Fulfillment resource in the [REST Admin API](https://shopify.dev/api/admin-rest):

    /orders/{order_id}/fulfillments.json
    /orders/{order_id}/fulfillments/{fulfillment_id}.json
    /orders/{order_id}/fulfillments/{fulfillment_id}/complete.json
    /orders/{order_id}/fulfillments/{fulfillment_id}/open.json
    /orders/{order_id}/fulfillments/{fulfillment_id}/cancel.json

Use the [FulfillmentOrder](https://shopify.dev/api/admin-rest/latest/resources/fulfillmentorder) resource instead.
---
### Removes
**FulfillmentService.php**

- [x] - update()
- [x] - complete()
- [x] - open()
---
### Additions 
**FulfillmentService.php**

- [x] `updateTracking()` endpoint
_FulfillmentFields_
- [x] `tracking_info property`
- [x] `line_items_by_fulfillment_order` property
---
### Fixes
**FulfillmentService.php**

- [x] cancel order endpoint